### PR TITLE
Remove unused glext import

### DIFF
--- a/GLV/glv_conf.h
+++ b/GLV/glv_conf.h
@@ -89,7 +89,6 @@
 	#include <time.h>
 	#include <GL/glew.h>
 	#include <GL/gl.h>
-	#include <GL/glext.h>
 
 	#define GLV_PLATFORM_INIT_CONTEXT\
 		{	GLenum err = glewInit();\


### PR DESCRIPTION
This makes the build work on my machines at least. Maybe it breaks it on less up to date systems?